### PR TITLE
fix(dependents): fix SyntaxError of import. (#954)

### DIFF
--- a/src/dependents.ts
+++ b/src/dependents.ts
@@ -39,7 +39,7 @@ export { default as Element } from '@antv/g2/lib/geometry/element';
 // Component
 import HtmlTooltip from '@antv/component/lib/tooltip/html';
 import HtmlTooltipTheme from '@antv/component/lib/tooltip/html-theme';
-import TooltipCssConst from '@antv/component/lib/tooltip/css-const';
+import * as TooltipCssConst from '@antv/component/lib/tooltip/css-const';
 export { HtmlTooltip, HtmlTooltipTheme, TooltipCssConst };
 export { GroupComponent, Axis, Legend, Tooltip, Slider, Scrollbar } from '@antv/component';
 export { GroupComponentCfg, TooltipCfg } from '@antv/component/lib/types';


### PR DESCRIPTION
当一个模块没有默认的导出变量时，使用不带括号的import语法（类似于import a from 'b')，可能会导致错误。